### PR TITLE
fix: reset mediaRecorderRef to prevent memory leak

### DIFF
--- a/src/components/VoiceRecorder.tsx
+++ b/src/components/VoiceRecorder.tsx
@@ -228,6 +228,8 @@ export const VoiceRecorder = ({
       // Sometimes stop() can throw an error if the recorder is in an invalid state
       try {
         mediaRecorderRef.current.stop();
+        mediaRecorderRef.current.ondataavailable = null;
+        mediaRecorderRef.current = null;
       } catch (e) {
         console.error("Error stopping MediaRecorder:", e);
       }


### PR DESCRIPTION
This PR fixes a potential memory leak in the media recording feature by properly resetting `mediaRecorderRef` after stopping.

- Remove event listeners (`ondataavailable`) after stopping recording.
- Prevent stale references by setting `mediaRecorderRef.current = null`.