### PR TITLE
fix: infinite loading issue when no notes are found

### DIFF
--- a/src/components/NoteList.tsx
+++ b/src/components/NoteList.tsx
@@ -72,6 +72,7 @@ export const NoteList = ({
         );
 
         setNotes(notesList);
+        setIsLoading(false);
 
         // Call the callback to pass notes to parent
         if (onNotesLoaded) {


### PR DESCRIPTION
This PR fixes an issue in `NoteList.tsx`. For new users with no notes, the "All Notes" page keeps showing a loader instead of an empty state. This happens because `setIsLoading(false)` is only triggered when an error occurs, and not after fetching data.